### PR TITLE
Fix json serialization error

### DIFF
--- a/shap/plots/_force.py
+++ b/shap/plots/_force.py
@@ -5,7 +5,7 @@ from __future__ import division, unicode_literals
 import os
 import io
 import string
-import json
+import simplejson as json
 import random
 try:
     from IPython.core.display import display, HTML


### PR DESCRIPTION
Replace `json` with `simplejson` library to avoid json serialization errors.

[Issue 2682](https://github.com/slundberg/shap/issues/2682)